### PR TITLE
make unobstructed coins collectable

### DIFF
--- a/replay.py
+++ b/replay.py
@@ -41,7 +41,12 @@ class ReplayWorld(GenericWorld):
 
         # Game world and objects
         self.arena = np.array(self.replay['arena'])
-        self.coins = [Coin(xy) for xy in self.replay['coins']]
+        self.coins = []
+        for xy in self.replay['coins']:
+            if self.arena[xy] == 0:
+                self.coins.append(Coin(xy, True))
+            else:
+                self.coins.append(Coin(xy, False))
         self.active_agents = [a for a in self.agents]
         for i, agent in enumerate(self.agents):
             agent.start_round()


### PR DESCRIPTION
When using the replay functionality together with `CRATE_DENSITY = 0` the game instantly ends because when creating the coins in the `ReplayWord` they are by default created as not collectable. This change makes unobstructed coins collectable.