### PR TITLE
reset self when entering new round

### DIFF
--- a/agent_code/rule_based_agent/callbacks.py
+++ b/agent_code/rule_based_agent/callbacks.py
@@ -70,6 +70,14 @@ def setup(self):
     self.coordinate_history = deque([], 20)
     # While this timer is positive, agent will not hunt/attack opponents
     self.ignore_others_timer = 0
+    self.current_round = 0
+
+
+def reset_self(self):
+    self.bomb_history = deque([], 5)
+    self.coordinate_history = deque([], 20)
+    # While this timer is positive, agent will not hunt/attack opponents
+    self.ignore_others_timer = 0
 
 
 def act(self, game_state):
@@ -81,7 +89,10 @@ def act(self, game_state):
     what it contains.
     """
     self.logger.info('Picking action according to rule set')
-
+    # Check if we are in a different round
+    if game_state["round"] != self.current_round:
+        reset_self(self)
+        self.current_round = game_state["round"]
     # Gather information about the game state
     arena = game_state['field']
     _, score, bombs_left, (x, y) = game_state['self']


### PR DESCRIPTION
Currently, the rule based agent doesn't reset its `bomb_history` and `coordinate_history` between different rounds.

This bug only presents itself when playing against a bad agent which kills itself very fast. This can in some cases lead to results where the rule based agent is completely stuck because the preferred bomb tile had a bomb placed on it in the previous round which disqualifies the agent from placing another bomb in its place.

![output](https://user-images.githubusercontent.com/16564897/110252089-f99a1480-7f83-11eb-9166-8c794d7630a8.gif)
