### PR TITLE
Initialise arguments before using it

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -44,8 +44,8 @@ class GenericWorld:
     round_id: str
 
     def __init__(self, args: WorldArgs):
-        self.setup_logging()
         self.args = args
+        self.setup_logging()
         if self.args.no_gui:
             self.gui = None
         else:


### PR DESCRIPTION
Currently, `GenericWorld` calls `self.setup_logging()` before it initialises `self.args`, which produces an error for some users. The pull request swaps the order of the initialisation and the call to `self.setup_logging()`.