### PR TITLE
store the last game state for end_of_round

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -462,6 +462,7 @@ class BombeRLeWorld(GenericWorld):
         # Clean up survivors
         for a in self.active_agents:
             a.add_event(e.SURVIVED_ROUND)
+            a.store_game_state(self.get_state_for_agent(a))
 
         # Send final event to agents that expect them
         for a in self.agents:


### PR DESCRIPTION
When running the `end_of_round` function, the last_game_state was actually the previous game state, this stores the real final game state