### PR TITLE
Fix "python main.py replay" AttributeError: 'Namespace' object has no attribute 'seed'

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -53,7 +53,7 @@ class GenericWorld:
         self.round = 0
         self.round_statistics = {}
 
-        self.rng = np.random.default_rng(args.seed)
+        self.rng = np.random.default_rng(args.seed if 'seed' in args else None)
 
         self.running = False
 


### PR DESCRIPTION
See the discord discussion, `python main.py replay` doesn't seem to work ,failing with

```
...environment.py", line 56, in __init__
    self.rng = np.random.default_rng(args.seed)
AttributeError: 'Namespace' object has no attribute 'seed'
```
It's expected that argparse always has a seed attribute, but for the replay world variant it's not the case.