### PR TITLE
Implicitly added support for Python3.6 and up

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ class Timekeeper:
             sleep(duration)
 
 
-def world_controller(world, n_rounds, /,
+def world_controller(world, n_rounds, *,
                      gui, every_step, turn_based, make_video, update_interval):
     if make_video and not gui.screenshot_dir.exists():
         gui.screenshot_dir.mkdir()


### PR DESCRIPTION
#19 
By changing the positional only parameter from `/` to `*` lower Python versions than 3.8 are supported too.
The `/` was added in [PEP 570](https://www.python.org/dev/peps/pep-0570/) and only works for 3.8
